### PR TITLE
feat: Add restart job

### DIFF
--- a/.github/actions/restart-app/action.yaml
+++ b/.github/actions/restart-app/action.yaml
@@ -1,9 +1,9 @@
-name: Build image and push it to dockerhub
-description: Builds image and pushes it to dockerhub
+name: Restart container
+description: Restarts container
 runs:
   using: "composite"
   steps:
-    - name: Connect to VM and start app
+    - name: Connect to VM and restart docker
       env:
         ADDRESS_VM: ${{inputs.ADDRESS_VM}}
         DOCKER_USERNAME: ${{ inputs.DOCKER_USERNAME }}
@@ -23,4 +23,4 @@ runs:
         mkdir ~/.ssh
         echo $KNOWN_HOSTS >> ~/.ssh/known_hosts
         echo "Connect to VM and start app..."
-        ssh -i ~/vm_key.key $ADDRESS_VM "cd /app && docker pull mimotej/oqix:latest &&" 'docker kill $(sudo docker ps -a -q); docker rm $(docker ps --filter status=exited -q);' "docker run -d -e DISCORD_TOKEN=$DISCORD_TOKEN -e CLIENT_ID=$CLIENT_ID -e GUILD_ID=$GUILD_ID -it --mount type=bind,source=/app/userLog.json,target=/root/userLog.json mimotej/oqix:latest"
+        ssh -i ~/vm_key.key $ADDRESS_VM "cd /app && " 'docker kill $(sudo docker ps -a -q); docker rm $(docker ps --filter status=exited -q);' "docker run -d -e DISCORD_TOKEN=$DISCORD_TOKEN -e CLIENT_ID=$CLIENT_ID -e GUILD_ID=$GUILD_ID -it --mount type=bind,source=/app/userLog.json,target=/root/userLog.json mimotej/oqix:latest"

--- a/.github/workflows/restart-app.yaml
+++ b/.github/workflows/restart-app.yaml
@@ -1,0 +1,22 @@
+name: Restart app in the cloud
+
+on:
+  workflow_dispatch
+jobs:
+  restart-app:
+    name: 'Restart app in Oracle OCI'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Deploy app
+        uses: ./.github/actions/restart-app
+        with:
+          ADDRESS_VM: ${{ secrets.ADDRESS_VM }}
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          DISCORD_TOKEN: ${{ secrets.DISCORD_TOKEN }}
+          CLIENT_ID: ${{ secrets.CLIENT_ID }}
+          GUILD_ID: ${{ secrets.GUILD_ID }}
+          SSH_KEY: ${{ secrets.SSH_KEY }}
+          KNOWN_HOSTS: ${{ secrets.KNOWN_HOSTS }}


### PR DESCRIPTION
This PR adds job to restart the app in the cloud + makes use of latest tag instead of sha in image (sha is still used in push to have archive of older versions...) To make restart usable deploy-app needs to be re-run