### PR TITLE
Add config and embed constructor

### DIFF
--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -1,0 +1,90 @@
+import { SlashCommandBuilder } from '@discordjs/builders';
+import {
+    APIApplicationCommandOptionChoice,
+    PermissionFlagsBits,
+} from 'discord-api-types/v9';
+import { CommandInteraction, GuildMember } from 'discord.js';
+import { Config, ConfigKey } from '../utils/config';
+import { Embed } from '../utils/embed';
+
+class StringOption implements APIApplicationCommandOptionChoice<string> {
+    value: string;
+    name: string;
+
+    constructor(val: string) {
+        this.value = val;
+        this.name = val;
+    }
+}
+
+export const data = new SlashCommandBuilder()
+    .setName('config')
+    .setDescription('Gets or sets config values')
+    .setDefaultMemberPermissions(PermissionFlagsBits.Administrator)
+    .addStringOption((option) =>
+        option
+            .setChoices(
+                {
+                    name: 'get',
+                    value: 'get',
+                },
+                {
+                    name: 'set',
+                    value: 'set',
+                },
+                {
+                    name: 'list',
+                    value: 'list',
+                }
+            )
+            .setName('action')
+            .setDescription('Command config action')
+            .setRequired(true)
+    )
+    .addStringOption((option) =>
+        option
+            .setName('property')
+            .setDescription('Config property')
+            .setRequired(false)
+            .setChoices(
+                ...Object.getOwnPropertyNames(Config.Instance.Properties).map(
+                    (x) => new StringOption(x)
+                )
+            )
+    )
+    .addStringOption((option) =>
+        option
+            .setName('value')
+            .setDescription('New config value, if setting property')
+    );
+
+export async function execute(interaction: CommandInteraction) {
+    const member = interaction.member as GuildMember;
+
+    const action = interaction.options.getString('action');
+    const property = interaction.options.getString('property');
+
+    const embed = Embed.GetDefault(member);
+
+    if (action == 'get') {
+        const value = Config.Instance.GetProperty(property as ConfigKey);
+        embed.addField(property ?? 'None', value);
+    } else if (action == 'list') {
+        const keys = Object.keys(Config.Instance) as ConfigKey[];
+        for (const key of keys) {
+            embed.addField(key, Config.Instance.Properties[key], true);
+        }
+    } else if (action == 'set') {
+        const newValue = interaction.options.getString('value') ?? 'None';
+        const oldValue = Config.Instance.GetProperty(property as ConfigKey);
+        Config.Instance.SetProperty(property as ConfigKey, newValue);
+        embed.setTitle(`Setting property ${property}`);
+        embed.addField('Old value', oldValue);
+        embed.addField('New value', newValue);
+    }
+
+    interaction.reply({
+        embeds: [embed],
+        ephemeral: true,
+    });
+}

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -7,3 +7,4 @@ export * as prune from './prune';
 export * as announce from './announce';
 export * as restart from './restart';
 export * as verify from './verify';
+export * as config from './config';

--- a/src/registerCommands.ts
+++ b/src/registerCommands.ts
@@ -1,4 +1,7 @@
-import { SlashCommandBuilder } from '@discordjs/builders';
+import {
+    SlashCommandBuilder,
+    SlashCommandSubcommandsOnlyBuilder,
+} from '@discordjs/builders';
 import { REST } from '@discordjs/rest';
 import { Routes } from 'discord-api-types/v9';
 import * as commandModules from './commands';
@@ -7,7 +10,9 @@ import * as commandModules from './commands';
  * Registers all commands.
  */
 type Command = {
-    data: Omit<SlashCommandBuilder, 'addSubcommand' | 'addSubcommandGroup'>;
+    data:
+        | Omit<SlashCommandBuilder, 'addSubcommand' | 'addSubcommandGroup'>
+        | SlashCommandSubcommandsOnlyBuilder;
 };
 export default () => {
     const commands = [];

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1,0 +1,54 @@
+import * as fs from 'fs';
+
+class ConfigProperties {
+    DefaultColor = '#0099ff';
+}
+
+export type ConfigKey = keyof ConfigProperties;
+
+export class Config {
+    private static _instance: Config;
+    public Properties!: ConfigProperties;
+    private configPath = './config.json';
+
+    public static get Instance(): Config {
+        if (!this._instance) {
+            this._instance = new Config();
+        }
+
+        return this._instance;
+    }
+
+    constructor() {
+        this.LoadConfig();
+    }
+
+    public SetProperty(property: ConfigKey, value: any) {
+        this.Properties[property] = value;
+        this.SaveConfig();
+    }
+
+    public GetProperty(property: ConfigKey) {
+        return this.Properties[property];
+    }
+
+    private SaveConfig() {
+        const configJson = JSON.stringify(this.Properties);
+        fs.writeFileSync(this.configPath, configJson);
+    }
+
+    public LoadConfig() {
+        if (fs.existsSync(this.configPath)) {
+            const configFile = fs.readFileSync(this.configPath, 'utf-8');
+            const configJson = JSON.parse(configFile);
+            this.Properties = configJson as ConfigProperties;
+        } else {
+            fs.writeFileSync(
+                this.configPath,
+                JSON.stringify(new ConfigProperties())
+            );
+            console.log(`${this.configPath} does not exist, creating new file`);
+            this.Properties = new ConfigProperties();
+        }
+    }
+}

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1,10 +1,18 @@
 import * as fs from 'fs';
 
-class ConfigProperties {
+export class ConfigProperties {
     DefaultColor = '#0099ff';
+    SubjectChannelGroupIDs: Array<string> = [];
 }
 
 export type ConfigKey = keyof ConfigProperties;
+export type ConfigValue =
+    | string
+    | string[]
+    | number
+    | number[]
+    | boolean
+    | boolean[];
 
 export class Config {
     private static _instance: Config;
@@ -23,13 +31,17 @@ export class Config {
         this.LoadConfig();
     }
 
-    public SetProperty(property: ConfigKey, value: any) {
-        this.Properties[property] = value;
+    public SetProperty(property: ConfigKey, value: ConfigValue) {
+        this.Properties[property] = value as never;
         this.SaveConfig();
     }
 
-    public GetProperty(property: ConfigKey) {
-        return this.Properties[property];
+    public GetPropertySerialized(property: ConfigKey): string {
+        const value = this.Properties[property];
+        if (typeof value === 'object') {
+            return JSON.stringify(this.Properties[property]);
+        }
+        return value.toString();
     }
 
     private SaveConfig() {
@@ -47,7 +59,6 @@ export class Config {
                 this.configPath,
                 JSON.stringify(new ConfigProperties())
             );
-            console.log(`${this.configPath} does not exist, creating new file`);
             this.Properties = new ConfigProperties();
         }
     }

--- a/src/utils/embed.ts
+++ b/src/utils/embed.ts
@@ -1,0 +1,23 @@
+import { ColorResolvable, GuildMember, MessageEmbed } from 'discord.js';
+import { Config } from './config';
+
+export abstract class Embed {
+    public static GetDefault(
+        member?: GuildMember,
+        color?: ColorResolvable | string
+    ): MessageEmbed {
+        const embed = new MessageEmbed();
+        if (member) {
+            embed.setFooter({
+                text: `Response to ${member.user.tag}`,
+                iconURL: member.displayAvatarURL(),
+            });
+        }
+        if (!color) {
+            color = Config.Instance.Properties.DefaultColor;
+        }
+        embed.setColor(color as ColorResolvable);
+        embed.setTimestamp();
+        return embed;
+    }
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,5 @@
 export { scrapeConfirmationStudies } from './scrapeConfirmationStudies';
 export { scrapeThesis } from './scrapeThesis';
 export { assignRole } from './assignRole';
+export { Config, ConfigKey, ConfigValue, ConfigProperties } from './config';
+export { Embed } from './embed';

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,0 +1,45 @@
+import { existsSync, renameSync } from 'fs';
+import { Config, ConfigKey, ConfigProperties } from '../src/utils';
+
+describe('Tests for config', () => {
+    let configProps: ConfigProperties;
+    let keys: ConfigKey[];
+    const backupConfigName = './config.backup.json';
+
+    beforeAll(() => {
+        configProps = new ConfigProperties();
+        keys = Object.keys(Config.Instance.Properties) as ConfigKey[];
+        if (existsSync('./config.json')) {
+            renameSync('./config.json', backupConfigName);
+        }
+    });
+
+    afterAll(() => {
+        if (existsSync(backupConfigName)) {
+            renameSync(backupConfigName, './config.json');
+        }
+    });
+
+    it('Config exists', () => {
+        Config.Instance.LoadConfig();
+        const exists = existsSync('./config.json');
+        expect(exists).toBeTruthy();
+    });
+
+    it('All values are default', () => {
+        for (const key of keys) {
+            expect(Config.Instance.Properties[key]).toEqual(configProps[key]);
+        }
+    });
+
+    it('New value is set', () => {
+        const key = keys[0];
+        const newValue = Math.random().toString(36).substring(2, 15);
+
+        expect(Config.Instance.Properties[key]).toEqual(configProps[key]);
+
+        Config.Instance.SetProperty(key, newValue);
+
+        expect(Config.Instance.Properties[key]).toEqual(newValue);
+    });
+});


### PR DESCRIPTION
# Related issues
In preparation for issue https://github.com/OqixDevs/OqixTS/issues/35

# Type of pull request
- [X] New feature
- [ ] Bug fix
- [ ] Refactoring
- [ ] Feature update
- [ ] Other

# Describe your PR in detail
Adds a new file `config.json` to root directory, and corresponding commands

- `/config list` to list all config properties
- `/config get [property]`  to get value of `property`
- `/config set [property] [value]` to set `value` for `property`
- `/config reload` to reload config from file

If `config.json` does not exist, it is created from default values located in [`class ConfigProperty`](https://github.com/hortjar/OqixTS/blob/472e66824c262083e0bc4cefc5b493c77c5e6f16/src/utils/config.ts#L3=). 

Also adds [`Embed`](https://github.com/hortjar/OqixTS/blob/472e66824c262083e0bc4cefc5b493c77c5e6f16/src/utils/embed.ts) constructor class that is used to respond in a prettier way than plain text. Default `Embed` contains current timestamp, optionally name of a user being replied to, and uses config property `DefaultColor` for color style.
 