### PR TITLE
Mentionable subject role, notification on new channel creation, refresh subject selects on channel creation

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,5 +1,5 @@
 import { Client, GatewayIntentBits } from 'discord.js';
-import { interactionListener } from './listeners';
+import { channelListener, interactionListener } from './listeners';
 import { default as registerCommands } from './registerCommands';
 import dotenv from 'dotenv';
 import { SubjectChannels } from './utils';
@@ -24,4 +24,5 @@ export default () => {
     });
 
     interactionListener(client);
+    channelListener(client);
 };

--- a/src/commands/channelrole.ts
+++ b/src/commands/channelrole.ts
@@ -80,6 +80,7 @@ export async function execute(interaction: ChatInputCommandInteraction) {
 
             await interaction.reply({
                 content: `\`${subjectCode}\` role created`,
+                ephemeral: true,
             });
             return;
         } else {

--- a/src/commands/channelrole.ts
+++ b/src/commands/channelrole.ts
@@ -1,0 +1,67 @@
+import {
+    ChatInputCommandInteraction,
+    GuildMemberRoleManager,
+    NonThreadGuildBasedChannel,
+    SlashCommandBuilder,
+} from 'discord.js';
+import { Config } from '../utils';
+
+export const data = new SlashCommandBuilder()
+    .setName('channelrole')
+    .setDescription('Add or remove channel role')
+    .addSubcommand((sub) =>
+        sub.setName('add').setDescription('Add corresponding channel role')
+    )
+    .addSubcommand((sub) =>
+        sub
+            .setName('remove')
+            .setDescription('Remove corresponding channel role')
+    );
+
+export async function execute(interaction: ChatInputCommandInteraction) {
+    const subcommand = interaction.options.getSubcommand();
+    const guild = interaction.guild;
+    const config = Config.Instance.Properties;
+    if (
+        !interaction.channel?.isThread() &&
+        !config.SubjectChannelGroupIDs.includes(
+            (interaction.channel as NonThreadGuildBasedChannel).parentId ?? '-1'
+        )
+    ) {
+        await interaction.reply({
+            content: `This channel has no special role`,
+            ephemeral: true,
+        });
+        return;
+    }
+
+    let action = '';
+    const channelName = (interaction.channel as NonThreadGuildBasedChannel)
+        .name;
+    const subjectCode = channelName
+        .substring(0, channelName.indexOf('-'))
+        .toUpperCase();
+    const subjectRole = guild?.roles.cache.find((r) => r.name == subjectCode);
+
+    if (!subjectRole) {
+        await interaction.reply({
+            content: `This channel has no special role`,
+            ephemeral: true,
+        });
+        return;
+    }
+
+    const roleManager = interaction.member?.roles as GuildMemberRoleManager;
+    if (subcommand == 'add') {
+        action = 'Added';
+        await roleManager.member.roles.add(subjectRole);
+    } else {
+        action = 'Removed';
+        await roleManager.member.roles.remove(subjectRole);
+    }
+
+    await interaction.reply({
+        content: `${action} role ${subjectCode}`,
+        ephemeral: true,
+    });
+}

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -105,7 +105,6 @@ export async function execute(interaction: ChatInputCommandInteraction) {
                 .split(',')
                 .filter((x) => x)
                 .map((x) => x.trim());
-            console.log(newValueArray);
             Config.Instance.SetProperty(
                 property as ConfigKey,
                 newValueArray as ConfigValue

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -9,3 +9,4 @@ export * as verify from './verify';
 export * as config from './config';
 export * as channelmanagement from './channelmanagement';
 export * as edit from './edit';
+export * as channelrole from './channelrole';

--- a/src/listeners/channelListener.ts
+++ b/src/listeners/channelListener.ts
@@ -23,7 +23,7 @@ export default (client: Client) => {
                 );
                 if (notifyChannel?.isTextBased()) {
                     await notifyChannel.send({
-                        content: `New subject channel created *#${channel.name}*`,
+                        content: `New course channel created \`#${channel.name}\``,
                     });
                 }
             }

--- a/src/listeners/channelListener.ts
+++ b/src/listeners/channelListener.ts
@@ -1,0 +1,42 @@
+import { Client } from 'discord.js';
+import { Config, SubjectChannels } from '../utils';
+/**
+ * Listens for channel events and calls the appropriate function.
+ * @param client The Discord client.
+ */
+export default (client: Client) => {
+    client.on('channelCreate', async (channel) => {
+        const guild = await client.guilds.fetch(channel.guildId);
+        const config = Config.Instance.Properties;
+        // processing subject channel creation
+        if (config.SubjectChannelGroupIDs.includes(channel?.parentId ?? '-1')) {
+            // Add to subject selector
+            await SubjectChannels.setupSubjectChannels(guild);
+
+            // Notify of creation
+            if (
+                config.NewChannelNotificationEnabled &&
+                config.NewChannelNotificationChannel
+            ) {
+                const notifyChannel = await client.channels.fetch(
+                    config.NewChannelNotificationChannel
+                );
+                if (notifyChannel?.isTextBased()) {
+                    await notifyChannel.send({
+                        content: `New subject channel created *#${channel.name}*`,
+                    });
+                }
+            }
+
+            // Create mentionable subject role
+            const subjectCode = channel.name
+                .substring(0, channel.name.indexOf('-'))
+                .toUpperCase();
+            await guild.roles.create({
+                mentionable: true,
+                name: `${subjectCode}`,
+                hoist: false,
+            });
+        }
+    });
+};

--- a/src/listeners/index.ts
+++ b/src/listeners/index.ts
@@ -2,3 +2,4 @@
  * Listeners which are called when event happens
  */
 export { default as interactionListener } from './interactionListener';
+export { default as channelListener } from './channelListener';

--- a/src/selects/channelSelect.ts
+++ b/src/selects/channelSelect.ts
@@ -5,6 +5,7 @@ import {
     PermissionsBitField,
     SelectMenuInteraction,
     TextChannel,
+    GuildMemberRoleManager,
 } from 'discord.js';
 
 export type SelectID = {
@@ -33,10 +34,21 @@ export async function execute(interaction: SelectMenuInteraction) {
             const userCanRead = userPermissions.has(
                 PermissionsBitField.Flags.ViewChannel
             );
+            const subjectCode = channel.name
+                .substring(0, channel.name.indexOf('-'))
+                .toUpperCase();
+            const subjectRole = interaction.guild?.roles.cache.find(
+                (r) => r.name == subjectCode
+            );
+            const roleManager = interaction.member
+                .roles as GuildMemberRoleManager;
             if (userCanRead) {
                 await textChannel.permissionOverwrites.delete(
                     interaction.member.user.id
                 );
+                if (subjectRole) {
+                    await roleManager.member.roles.remove(subjectRole);
+                }
             } else {
                 await textChannel.permissionOverwrites.create(
                     interaction.member.user.id,
@@ -46,6 +58,9 @@ export async function execute(interaction: SelectMenuInteraction) {
                         SendMessagesInThreads: true,
                     }
                 );
+                if (subjectRole) {
+                    await roleManager.member.roles.add(subjectRole);
+                }
             }
         }
     }

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -3,6 +3,8 @@ import * as fs from 'fs';
 export class ConfigProperties {
     DefaultColor = '#0099ff';
     SubjectChannelGroupIDs: Array<string> = [];
+    NewChannelNotificationEnabled = false;
+    NewChannelNotificationChannel = '';
 }
 
 export type ConfigKey = keyof ConfigProperties;
@@ -40,6 +42,8 @@ export class Config {
         const value = this.Properties[property];
         if (typeof value === 'object') {
             return JSON.stringify(this.Properties[property]);
+        } else if (value == '') {
+            return '*empty*';
         }
         return value.toString();
     }
@@ -53,7 +57,11 @@ export class Config {
         if (fs.existsSync(this.configPath)) {
             const configFile = fs.readFileSync(this.configPath, 'utf-8');
             const configJson = JSON.parse(configFile);
-            this.Properties = configJson as ConfigProperties;
+            const propertiesObject = Object.assign(
+                new ConfigProperties(),
+                configJson
+            );
+            this.Properties = propertiesObject as ConfigProperties;
         } else {
             fs.writeFileSync(
                 this.configPath,


### PR DESCRIPTION
# Type of pull request
- [X] New feature
- [X] Feature update

# Describe your PR in detail
Created a new listener for channel creation, if the created channel is under any subject channel group, bot will create a mentionable role with subject code. Also added a new config property to enable sending messages (notifications) when a new subject channel is created.
Subject roles will be given to users when they select the channel, or by using command `/channelrole add`. Role will be removed when subject is deselected, or by using `/channelrole remove`
